### PR TITLE
Import Tailwind CSS in index.css

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,5 @@
+@import "tailwindcss";
+
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;


### PR DESCRIPTION
Added Tailwind CSS import to index.css to enable utility-first styling throughout the project.